### PR TITLE
update to remove travis_retry call

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,8 @@ install:
   - qiita-env make --no-load-ontologies
   - export QIITA_SERVER_CERT=$HOME/miniconda3/envs/qiita_env/lib/python2.7/site-packages/qiita_core/support_files/server.crt
   - pip install https://github.com/qiita-spots/qiita_client/archive/master.zip
-  - travis_retry pip install .
+#  - travis_retry pip install .
+  - pip install .
 before_script:
   - export MOI_CONFIG_FP=$HOME/miniconda3/envs/qiita_env/lib/python2.7/site-packages/qiita_core/support_files/config_test.cfg
   - qiita pet webserver start &


### PR DESCRIPTION
travis_retry not valid on jenkins systems.  rescheduling of job on non-zero return can be scheduled through jenkins server.
