### PR TITLE
fixing problem with != python2.7.6

### DIFF
--- a/qp_shotgun/humann2/__init__.py
+++ b/qp_shotgun/humann2/__init__.py
@@ -75,7 +75,7 @@ dflt_param_set = {
         'nucleotide-database': 'default', 'protein-database': 'default',
         'bypass-prescreen': False, 'bypass-nucleotide-index': False,
         'bypass-translated-search': False, 'bypass-nucleotide-search': False,
-        'annotation-gene-index': 8, 'evalue': 1.0, 
+        'annotation-gene-index': 8, 'evalue': 1.0,
         'metaphlan-options': '-t rel_ab', 'log-level': 'DEBUG',
         'remove-temp-output': False, 'threads': 1,
         'prescreen-threshold': 0.01, 'identity-threshold': 50.0,

--- a/qp_shotgun/humann2/__init__.py
+++ b/qp_shotgun/humann2/__init__.py
@@ -26,8 +26,8 @@ opt_params = {
     # id-mapping
     # pathways-database
     # o-log
-    'nucleotide-database': ['choice:["chocophlan"]', 'chocophlan'],
-    'protein-database': ['choice:["uniref"]', 'uniref'],
+    'nucleotide-database': ['choice:["default"]', 'default'],
+    'protein-database': ['choice:["default"]', 'default'],
     'bypass-prescreen': ['boolean', 'False'],
     'bypass-nucleotide-index': ['boolean', 'False'],
     'bypass-translated-search': ['boolean', 'False'],
@@ -73,7 +73,7 @@ outputs = {
     'Path abundance RELAB table - unstratified': 'BIOM'}
 dflt_param_set = {
     'Defaults': {
-        'nucleotide-database': 'chocophlan', 'protein-database': 'uniref',
+        'nucleotide-database': 'default', 'protein-database': 'default',
         'bypass-prescreen': False, 'bypass-nucleotide-index': False,
         'bypass-translated-search': False, 'bypass-nucleotide-search': False,
         'annotation-gene-index': 8, 'evalue': 1.0, 'search-mode': '',

--- a/qp_shotgun/humann2/__init__.py
+++ b/qp_shotgun/humann2/__init__.py
@@ -26,6 +26,8 @@ opt_params = {
     # id-mapping
     # pathways-database
     # o-log
+    # input-format
+    # search-mode
     'nucleotide-database': ['choice:["default"]', 'default'],
     'protein-database': ['choice:["default"]', 'default'],
     'bypass-prescreen': ['boolean', 'False'],
@@ -34,7 +36,6 @@ opt_params = {
     'bypass-nucleotide-search': ['boolean', 'False'],
     'annotation-gene-index': ['integer', '8'],
     'evalue': ['float', '1.0'],
-    'search-mode': ['choice:["", "uniref50", "uniref90"]', ''],
     'metaphlan-options': ['string', '-t rel_ab'],
     'log-level': ['choice:["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"]',
                   'DEBUG'],
@@ -53,8 +54,6 @@ opt_params = {
     'output-format': ['choice:["tsv", "biom"]', 'biom'],
     'output-max-decimals': ['integer', '10'],
     'remove-stratified-output': ['boolean', 'False'],
-    'input-format': ['choice:["", "fastq", "fastq.gz", "fasta", "fasta.gz", '
-                     '"sam", "bam", "blastm8", "genetable", "biom"]', ''],
     'pathways': ['choice:["metacyc", "unipathway"]', 'metacyc'],
     'memory-use': ['choice:["minimum", "maximum"]', 'minimum'],
     'remove-column-description-output': ['boolean', 'True']}
@@ -76,7 +75,7 @@ dflt_param_set = {
         'nucleotide-database': 'default', 'protein-database': 'default',
         'bypass-prescreen': False, 'bypass-nucleotide-index': False,
         'bypass-translated-search': False, 'bypass-nucleotide-search': False,
-        'annotation-gene-index': 8, 'evalue': 1.0, 'search-mode': '',
+        'annotation-gene-index': 8, 'evalue': 1.0, 
         'metaphlan-options': '-t rel_ab', 'log-level': 'DEBUG',
         'remove-temp-output': False, 'threads': 1,
         'prescreen-threshold': 0.01, 'identity-threshold': 50.0,
@@ -86,7 +85,7 @@ dflt_param_set = {
         'xipe': 'off', 'minpath': 'on', 'pick-frames': 'off',
         'gap-fill': 'off', 'output-format': 'biom',
         'output-max-decimals': 10, 'remove-stratified-output': False,
-        'input-format': '', 'pathways': 'metacyc', 'memory-use': 'minimum'}
+        'pathways': 'metacyc', 'memory-use': 'minimum'}
 }
 humann2_cmd = QiitaCommand(
     "HUMAnN2 0.9.1", "Community profiling", humann2, req_params, opt_params,

--- a/qp_shotgun/humann2/humann2.py
+++ b/qp_shotgun/humann2/humann2.py
@@ -91,7 +91,7 @@ def generate_humann2_analysis_commands(forward_seqs, reverse_seqs, map_file,
     cmds = []
     params = []
     for k, v in viewitems(parameters):
-        if not v:
+        if v is False or v in ['False', 'default']:
             continue
         if v is True or v == 'True':
             params.append('--%s' % k)

--- a/qp_shotgun/humann2/humann2.py
+++ b/qp_shotgun/humann2/humann2.py
@@ -91,7 +91,7 @@ def generate_humann2_analysis_commands(forward_seqs, reverse_seqs, map_file,
     cmds = []
     params = []
     for k, v in viewitems(parameters):
-        if v is False or v in ['False', 'default']:
+        if v is False or v in ['False', 'default', '']:
             continue
         if v is True or v == 'True':
             params.append('--%s' % k)

--- a/qp_shotgun/humann2/humann2.py
+++ b/qp_shotgun/humann2/humann2.py
@@ -89,8 +89,14 @@ def generate_humann2_analysis_commands(forward_seqs, reverse_seqs, map_file,
             % ', '.join(sn_by_rp.keys()))
 
     cmds = []
-    params = ['--%s "%s"' % (k, v) if v is not True else '--%s' % k
-              for k, v in viewitems(parameters) if v]
+    params = []
+    for k, v in viewitems(parameters):
+        if not v:
+            continue
+        if v is True or v == 'True':
+            params.append('--%s' % k)
+        else:
+            params.append('--%s "%s"' % (k, v))
     for ffn, fn, s in samples:
         od = join(out_dir, fn)
         # just making sure the output directory exists

--- a/qp_shotgun/humann2/tests/test_humann2.py
+++ b/qp_shotgun/humann2/tests/test_humann2.py
@@ -25,11 +25,11 @@ class Humann2Tests(PluginTestCase):
     def setUp(self):
         plugin("https://localhost:21174", 'register', 'ignored')
         self.params = {
-            'nucleotide-database': 'chocophlan', 'protein-database': 'uniref',
+            'nucleotide-database': 'default', 'protein-database': 'default',
             'bypass-prescreen': False, 'bypass-nucleotide-index': False,
             'bypass-translated-search': False,
             'bypass-nucleotide-search': False,
-            'annotation-gene-index': 8, 'evalue': 1.0, 'search-mode': '',
+            'annotation-gene-index': 8, 'evalue': 1.0,
             'metaphlan-options': '-t rel_ab', 'log-level': 'DEBUG',
             'remove-temp-output': False, 'threads': 1,
             'prescreen-threshold': 0.01, 'identity-threshold': 50.0,
@@ -39,7 +39,7 @@ class Humann2Tests(PluginTestCase):
             'xipe': 'off', 'minpath': 'on', 'pick-frames': 'off',
             'gap-fill': 'off', 'output-format': 'biom',
             'output-max-decimals': 10, 'remove-stratified-output': False,
-            'input-format': '', 'pathways': 'metacyc',
+            'pathways': 'metacyc',
             'memory-use': 'minimum', 'remove-column-description-output': True}
         self._clean_up_files = []
 
@@ -91,9 +91,9 @@ class Humann2Tests(PluginTestCase):
             '--prescreen-threshold "0.01" '
             '--translated-subject-coverage-threshold "50.0" --evalue "1.0" '
             '--minpath "on" --output-max-decimals "10" '
-            '--nucleotide-database "chocophlan" --memory-use "minimum" '
+            '--memory-use "minimum" '
             '--xipe "off" --annotation-gene-index "8" '
-            '--protein-database "uniref" --threads "1" --pathways "metacyc" '
+            '--threads "1" --pathways "metacyc" '
             '--pick-frames "off" --translated-alignment "diamond" '
             '--remove-column-description-output --log-level "DEBUG"' % out_dir,
             'humann2 --input "fastq/s2.fastq.gz" --output "%s/s2" '
@@ -105,9 +105,9 @@ class Humann2Tests(PluginTestCase):
             '--prescreen-threshold "0.01" '
             '--translated-subject-coverage-threshold "50.0" --evalue "1.0" '
             '--minpath "on" --output-max-decimals "10" '
-            '--nucleotide-database "chocophlan" --memory-use "minimum" '
+            '--memory-use "minimum" '
             '--xipe "off" --annotation-gene-index "8" '
-            '--protein-database "uniref" --threads "1" --pathways "metacyc" '
+            '--threads "1" --pathways "metacyc" '
             '--pick-frames "off" --translated-alignment "diamond" '
             '--remove-column-description-output --log-level "DEBUG"' % out_dir,
             'humann2 --input "fastq/s3.fastq" --output "%s/s3" '
@@ -119,9 +119,9 @@ class Humann2Tests(PluginTestCase):
             '--prescreen-threshold "0.01" '
             '--translated-subject-coverage-threshold "50.0" --evalue "1.0" '
             '--minpath "on" --output-max-decimals "10" '
-            '--nucleotide-database "chocophlan" --memory-use "minimum" '
+            '--memory-use "minimum" '
             '--xipe "off" --annotation-gene-index "8" '
-            '--protein-database "uniref" --threads "1" --pathways "metacyc" '
+            '--threads "1" --pathways "metacyc" '
             '--pick-frames "off" --translated-alignment "diamond" '
             '--remove-column-description-output --log-level "DEBUG"' % out_dir]
         obs = generate_humann2_analysis_commands(
@@ -149,9 +149,9 @@ class Humann2Tests(PluginTestCase):
             '--prescreen-threshold "0.01" '
             '--translated-subject-coverage-threshold "50.0" --evalue "1.0" '
             '--minpath "on" --output-max-decimals "10" '
-            '--nucleotide-database "chocophlan" --memory-use "minimum" '
+            '--memory-use "minimum" '
             '--xipe "off" --annotation-gene-index "8" '
-            '--protein-database "uniref" --threads "1" --pathways "metacyc" '
+            '--threads "1" --pathways "metacyc" '
             '--pick-frames "off" --translated-alignment "diamond" '
             '--remove-column-description-output --log-level "DEBUG"' % out_dir,
             'humann2 --input "fastq/s1.R2.fastq" --output "%s/s1.R2" '
@@ -163,9 +163,9 @@ class Humann2Tests(PluginTestCase):
             '--prescreen-threshold "0.01" '
             '--translated-subject-coverage-threshold "50.0" --evalue "1.0" '
             '--minpath "on" --output-max-decimals "10" '
-            '--nucleotide-database "chocophlan" --memory-use "minimum" '
+            '--memory-use "minimum" '
             '--xipe "off" --annotation-gene-index "8" '
-            '--protein-database "uniref" --threads "1" '
+            '--threads "1" '
             '--pathways "metacyc" --pick-frames "off" '
             '--translated-alignment "diamond" '
             '--remove-column-description-output --log-level "DEBUG"' % out_dir,
@@ -178,9 +178,9 @@ class Humann2Tests(PluginTestCase):
             '--prescreen-threshold "0.01" '
             '--translated-subject-coverage-threshold "50.0" --evalue "1.0" '
             '--minpath "on" --output-max-decimals "10" '
-            '--nucleotide-database "chocophlan" --memory-use "minimum" '
-            '--xipe "off" --annotation-gene-index "8" --protein-database '
-            '"uniref" --threads "1" --pathways "metacyc" --pick-frames "off" '
+            '--memory-use "minimum" '
+            '--xipe "off" --annotation-gene-index "8" '
+            '--threads "1" --pathways "metacyc" --pick-frames "off" '
             '--translated-alignment "diamond" '
             '--remove-column-description-output --log-level "DEBUG"' % out_dir,
             'humann2 --input "fastq/s2.R2.fastq.gz" --output "%s/s2.R2" '
@@ -192,9 +192,9 @@ class Humann2Tests(PluginTestCase):
             '--prescreen-threshold "0.01" '
             '--translated-subject-coverage-threshold "50.0" '
             '--evalue "1.0" --minpath "on" --output-max-decimals "10" '
-            '--nucleotide-database "chocophlan" --memory-use "minimum" '
+            '--memory-use "minimum" '
             '--xipe "off" --annotation-gene-index "8" '
-            '--protein-database "uniref" --threads "1" --pathways "metacyc" '
+            '--threads "1" --pathways "metacyc" '
             '--pick-frames "off" --translated-alignment "diamond" '
             '--remove-column-description-output --log-level "DEBUG"' % out_dir,
             'humann2 --input "fastq/s3.fastq" --output "%s/s3" '
@@ -206,9 +206,9 @@ class Humann2Tests(PluginTestCase):
             '--prescreen-threshold "0.01" '
             '--translated-subject-coverage-threshold "50.0" '
             '--evalue "1.0" --minpath "on" --output-max-decimals "10" '
-            '--nucleotide-database "chocophlan" --memory-use "minimum" '
+            '--memory-use "minimum" '
             '--xipe "off" --annotation-gene-index "8" '
-            '--protein-database "uniref" --threads "1" --pathways "metacyc" '
+            '--threads "1" --pathways "metacyc" '
             '--pick-frames "off" --translated-alignment "diamond" '
             '--remove-column-description-output --log-level "DEBUG"' % out_dir,
             'humann2 --input "fastq/s3.R2.fastq" --output "%s/s3.R2" '
@@ -220,9 +220,9 @@ class Humann2Tests(PluginTestCase):
             '--prescreen-threshold "0.01" '
             '--translated-subject-coverage-threshold "50.0" --evalue "1.0" '
             '--minpath "on" --output-max-decimals "10" '
-            '--nucleotide-database "chocophlan" --memory-use "minimum" '
+            '--memory-use "minimum" '
             '--xipe "off" --annotation-gene-index "8" '
-            '--protein-database "uniref" --threads "1" --pathways "metacyc" '
+            '--threads "1" --pathways "metacyc" '
             '--pick-frames "off" --translated-alignment "diamond" '
             '--remove-column-description-output --log-level "DEBUG"' % out_dir]
         obs = generate_humann2_analysis_commands(

--- a/qp_shotgun/humann2/tests/test_humann2.py
+++ b/qp_shotgun/humann2/tests/test_humann2.py
@@ -16,7 +16,7 @@ from os.path import exists, isdir, basename, join
 from qiita_client.testing import PluginTestCase
 
 
-from qp_shotgun.humann2 import plugin
+from qp_shotgun import plugin
 from qp_shotgun.humann2.humann2 import (
     humann2, generate_humann2_analysis_commands)
 
@@ -270,7 +270,7 @@ class Humann2Tests(PluginTestCase):
         self.params['nucleotide-database'] = ''
         self.params['protein-database'] = ''
         data = {'user': 'demo@microbio.me',
-                'command': dumps(['HUMAnN2', '0.9.1', 'HUMAnN2']),
+                'command': dumps(['qp-shotgun', '0.0.1', 'HUMAnN2 0.9.1']),
                 'status': 'running',
                 'parameters': dumps(self.params)}
         jid = self.qclient.post('/apitest/processing_job/', data=data)['job']

--- a/scripts/configure_shotgun
+++ b/scripts/configure_shotgun
@@ -10,7 +10,7 @@
 
 import click
 
-from qp_shotgun.humann2 import plugin
+from qp_shotgun import plugin
 
 
 @click.command()


### PR DESCRIPTION
Turns out that the behavior that @tanaes reported is the default and only works fine on 2.7.6. Thus, changing so we don't have to be dependent on a specific version. 
